### PR TITLE
version 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # A to Z Index #
-**Contributors:** diddledan  
-**Tags:** a to z, a-z, archive, listing, widget, index  
-**Requires at least:** 3.5  
-**Tested up to:** 4.4  
-**Stable tag:** 0.7.2  
-**License:** GPLv2 or later  
-**License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
+**Contributors:** diddledan
+**Tags:** a to z, a-z, archive, listing, widget, index
+**Requires at least:** 3.5
+**Tested up to:** 4.5
+**Stable tag:** 0.8.0
+**License:** GPLv2 or later
+**License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
 Provides an A to Z index page and widget. The widget links to the index page at the appropriate letter.
 
@@ -41,7 +41,7 @@ placing the a-z index on a child of section1 will likewise limit the index page 
 Likewise for section2, section2a and section2b.
 
 ### NOTE ###
-Styling (CSS) is left entirely up to the developer or site owner.
+Styling (CSS) is *off* by default. See the FAQ section for details to turn-on in-built styles.
 
 ## Installation ##
 
@@ -50,7 +50,7 @@ This section describes how to install the plugin and get it working.
 1. Upload the `a-z-listing` folder to the `/wp-content/plugins/` directory
 1. Activate the plugin through the 'Plugins' menu in WordPress
 1. Place `<?php the_az_listing(); ?>` in your templates for the index page output or use the `a-z-listing` shortcode.
-1. Add the A-Z Site Map widget to a sidebar or use `<?php the_az_widget(null, array('post' => get_page($id))); ?>` in your templates (the 'post' variable indicates where the A-Z Index page is located).
+1. Add the A-Z Site Map widget to a sidebar or use `<?php the_a_z_widget(null, array('post' => get_page($id))); ?>` in your templates (the 'post' variable indicates where the A-Z Index page is located).
 
 ## Shortcode ##
 
@@ -76,13 +76,22 @@ The theme system this plugin implements is very similar to the standard WordPres
 
 Important functions to use in your template are as follows:
 
-* `the_az_letters()` outputs the full alphabet, and links the letters that have posts to their section within the index page.
+* `the_a_z_letters()` outputs the full alphabet, and links the letters that have posts to their section within the index page.
 * `have_a_z_letters()` returns true or false depending on whether there are any letters left to loop-through. This is part of the Letter Loop.
-* `have_a_z_posts()` this behaves very similarly to Core's `have_posts()` function. It is part of the Post Loop.
-* `the_a_z_letter()` similar to Core's `the_post`, this will set-up the next iteration of the A-Z Listing's Letter Loop. This needs to wrap-around the Post Loop.
-* `the_a_z_post()` similar to Core's `the_post`, this will set-up the next iteration of the A-Z Listing's _Post_ Loop. This needs to be _within_ the Letter Loop.
+* `have_a_z_items()` this behaves very similarly to Core's `have_posts()` function. It is part of the Item Loop.
+* `the_a_z_letter()` similar to Core's `the_post`, this will set-up the next iteration of the A-Z Listing's Letter Loop. This needs to wrap-around the Item Loop.
+* `the_a_z_item()` similar to Core's `the_post`, this will set-up the next iteration of the A-Z Listing's Item Loop, the same way the normal WordPress Loop works. This needs to be _within_ the Letter Loop.
 
 When you are within the Post Loop you can utilise all in-built WordPress Core post-related functions such as `the_title()`, `the_permalink`, `the_content`, etc.
+
+### Helper functions ###
+
+In 0.8.0 we added taxonomy-terms listings to the featureset. This means that the WordPress functions related to posts such as `the_title` and `the_permalink` are unreliable. We have therefore added helper functions which will return or print the correct output for the item.
+
+These helper functions cope with the duality of the plugin supporting both WP_Query-based and Taxonomy Terms listings. These are:
+
+* `the_a_z_item_title()` - returns the current item's Title
+* `the_a_z_item_permalink()` returns the current item's Permalink
 
 ## Frequently Asked Questions ##
 
@@ -91,13 +100,21 @@ When you are within the Post Loop you can utilise all in-built WordPress Core po
 in your theme's functions.php add the following code:
 
     <?php
-    add_filter('az_sections', 'remove_az_section_targeting');
-    function remove_az_section_targeting($sections) {
+    add_filter('a-z-listing-sections', 'remove_a_z_section_targeting');
+    function remove_a_z_section_targeting($sections) {
         return array();
     }
     ?>
 
 This filter can also be used, by removing entries which are standard $post variables, to limit which top-level pages are used as section identifiers.
+
+### How do I apply the in-built styling? ###
+
+in your theme's functions.php add the following code:
+
+    <?php
+    add_filter( 'a-z-listing-add-styling', '__return_true' );
+    ?>
 
 ## Screenshots ##
 
@@ -107,8 +124,14 @@ This filter can also be used, by removing entries which are standard $post varia
 ### 2. The Widget is shown here. ###
 ![2. The Widget is shown here.](http://ps.w.org/a-to-z-index/assets/screenshot-2.png)
 
-
 ## Changelog ##
+
+### 0.8.0 ###
+* Standardised on naming convention of *_a_z_* in function names, e.g. `get_the_a_z_listing()`, rather than the former *_az_* names, e.g. `get_the_az_listing()`.
+* Converted version numbering to semver style.
+* Fixed the in-built styling.
+* Added filter to determine whether to apply in-built styles in addition to hidden setting: `set_option( a-z-listing-add-styling', true );`.
+* Added taxonomy terms list support.
 
 ### 0.7.1 ###
 * Fix potential XSS vector.

--- a/a-z-listing.php
+++ b/a-z-listing.php
@@ -53,7 +53,7 @@ function bh_az_listing_init() {
 	$country = substr( $locale, 3, 2 );
 
 	if ( is_readable( $dir . 'languages/' . $lang . '-' . $country . '.php' ) ) {
-			require_once( $dir . 'languages/' . $lang . '-' . $country . '.php' );
+		require_once( $dir . 'languages/' . $lang . '-' . $country . '.php' );
 	} else if ( is_readable( $dir . 'languages/' . $lang . '.php' ) ) {
 		require_once( $dir . 'languages/' . $lang . '.php' );
 	}

--- a/css/a-z-listing-default.css
+++ b/css/a-z-listing-default.css
@@ -1,16 +1,45 @@
-.a-z-listing-widget.default-style .letter .az-letters:after {
-  content: "";
-  display: table;
-  clear: both; }
+.az-letters {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+      -ms-flex-pack: center;
+          justify-content: center; }
+  .az-letters:after {
+    content: "";
+    display: table;
+    clear: both; }
+  .az-letters ul.az-links {
+    padding: 0;
+    margin: 0; }
+    .az-letters ul.az-links li {
+      list-style: none;
+      float: left;
+      width: 2em;
+      height: 2em;
+      box-sizing: border-box;
+      margin: 0.15em;
+      border: 1px solid #8bf;
+      background: #adf;
+      color: black;
+      display: -webkit-box;
+      display: -webkit-flex;
+      display: -ms-flexbox;
+      display: flex;
+      -webkit-box-align: center;
+      -webkit-align-items: center;
+          -ms-flex-align: center;
+              align-items: center;
+      -webkit-box-pack: center;
+      -webkit-justify-content: center;
+          -ms-flex-pack: center;
+              justify-content: center; }
+      .az-letters ul.az-links li a {
+        color: black;
+        font-weight: bold;
+        font-size: 1.6em;
+        text-decoration: none; }
 
-.a-z-listing-widget.default-style .letter .az-letters ul.az-links li {
-  float: left;
-  width: 2em;
-  height: 2em;
-  box-sizing: border-box;
-  margin: 0.15em;
-  border: 1px solid #8bf;
-  background: #adf;
-  color: black; }
-
-/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImEtei1saXN0aW5nLWRlZmF1bHQuc2NzcyIsIm1peGlucy5zY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVBO0VDQVEsWUFBWTtFQUNaLGVBQWU7RUFDZixZQUFZLEVBQ2Y7O0FESEw7RUFNb0IsWUFBWTtFQUNaLFdBQVc7RUFDWCxZQUFZO0VBQ1osdUJBQXVCO0VBQ3ZCLGVBQWU7RUFDZix1QkFBdUI7RUFDdkIsaUJBQWlCO0VBQ2pCLGFBQWEsRUFDaEIiLCJmaWxlIjoiYS16LWxpc3RpbmctZGVmYXVsdC5jc3MiLCJzb3VyY2VzQ29udGVudCI6WyJAaW1wb3J0IFwibWl4aW5zLnNjc3NcIjtcblxuLmEtei1saXN0aW5nLXdpZGdldC5kZWZhdWx0LXN0eWxlIHtcbiAgICAubGV0dGVyIHtcbiAgICAgICAgLmF6LWxldHRlcnMge1xuICAgICAgICAgICAgQGluY2x1ZGUgY2xlYXJmaXgoKTtcbiAgICAgICAgICAgIHVsLmF6LWxpbmtzIHtcbiAgICAgICAgICAgICAgICBsaSB7XG4gICAgICAgICAgICAgICAgICAgIGZsb2F0OiBsZWZ0O1xuICAgICAgICAgICAgICAgICAgICB3aWR0aDogMmVtO1xuICAgICAgICAgICAgICAgICAgICBoZWlnaHQ6IDJlbTtcbiAgICAgICAgICAgICAgICAgICAgYm94LXNpemluZzogYm9yZGVyLWJveDtcbiAgICAgICAgICAgICAgICAgICAgbWFyZ2luOiAwLjE1ZW07XG4gICAgICAgICAgICAgICAgICAgIGJvcmRlcjogMXB4IHNvbGlkICM4YmY7XG4gICAgICAgICAgICAgICAgICAgIGJhY2tncm91bmQ6ICNhZGY7XG4gICAgICAgICAgICAgICAgICAgIGNvbG9yOiBibGFjaztcbiAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICB9XG4gICAgICAgIH1cbiAgICB9XG59XG4iLCLvu79AbWl4aW4gY2xlYXJmaXgge1xuICAgICY6YWZ0ZXIge1xuICAgICAgICBjb250ZW50OiBcIlwiO1xuICAgICAgICBkaXNwbGF5OiB0YWJsZTtcbiAgICAgICAgY2xlYXI6IGJvdGg7XG4gICAgfVxufVxuIl0sInNvdXJjZVJvb3QiOiIvc291cmNlLyJ9 */
+/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImEtei1saXN0aW5nLWRlZmF1bHQuc2NzcyIsIm1peGlucy5zY3NzIl0sIm5hbWVzIjpbXSwibWFwcGluZ3MiOiJBQUVBO0VBRUkscUJBQWM7RUFBZCxzQkFBYztFQUFkLHFCQUFjO0VBQWQsY0FBYztFQUNkLHlCQUF3QjtFQUF4QixnQ0FBd0I7TUFBeEIsc0JBQXdCO1VBQXhCLHdCQUF3QixFQXlCM0I7RUE1QkQ7SUNBUSxZQUFZO0lBQ1osZUFBZTtJQUNmLFlBQVksRUFDZjtFREhMO0lBS1EsV0FBVztJQUNYLFVBQVUsRUFxQmI7SUEzQkw7TUFRWSxpQkFBaUI7TUFDakIsWUFBWTtNQUNaLFdBQVc7TUFDWCxZQUFZO01BQ1osdUJBQXVCO01BQ3ZCLGVBQWU7TUFDZix1QkFBdUI7TUFDdkIsaUJBQWlCO01BQ2pCLGFBQWE7TUFDYixxQkFBYztNQUFkLHNCQUFjO01BQWQscUJBQWM7TUFBZCxjQUFjO01BQ2QsMEJBQW9CO01BQXBCLDRCQUFvQjtVQUFwQix1QkFBb0I7Y0FBcEIsb0JBQW9CO01BQ3BCLHlCQUF3QjtNQUF4QixnQ0FBd0I7VUFBeEIsc0JBQXdCO2NBQXhCLHdCQUF3QixFQU8zQjtNQTFCVDtRQXFCZ0IsYUFBYTtRQUNiLGtCQUFrQjtRQUNsQixpQkFBaUI7UUFDakIsc0JBQXNCLEVBQ3pCIiwiZmlsZSI6ImEtei1saXN0aW5nLWRlZmF1bHQuY3NzIiwic291cmNlc0NvbnRlbnQiOlsiQGltcG9ydCBcIm1peGlucy5zY3NzXCI7XG5cbi5hei1sZXR0ZXJzIHtcbiAgICBAaW5jbHVkZSBjbGVhcmZpeCgpO1xuICAgIGRpc3BsYXk6IGZsZXg7XG4gICAganVzdGlmeS1jb250ZW50OiBjZW50ZXI7XG4gICAgdWwuYXotbGlua3Mge1xuICAgICAgICBwYWRkaW5nOiAwO1xuICAgICAgICBtYXJnaW46IDA7XG4gICAgICAgIGxpIHtcbiAgICAgICAgICAgIGxpc3Qtc3R5bGU6IG5vbmU7XG4gICAgICAgICAgICBmbG9hdDogbGVmdDtcbiAgICAgICAgICAgIHdpZHRoOiAyZW07XG4gICAgICAgICAgICBoZWlnaHQ6IDJlbTtcbiAgICAgICAgICAgIGJveC1zaXppbmc6IGJvcmRlci1ib3g7XG4gICAgICAgICAgICBtYXJnaW46IDAuMTVlbTtcbiAgICAgICAgICAgIGJvcmRlcjogMXB4IHNvbGlkICM4YmY7XG4gICAgICAgICAgICBiYWNrZ3JvdW5kOiAjYWRmO1xuICAgICAgICAgICAgY29sb3I6IGJsYWNrO1xuICAgICAgICAgICAgZGlzcGxheTogZmxleDtcbiAgICAgICAgICAgIGFsaWduLWl0ZW1zOiBjZW50ZXI7XG4gICAgICAgICAgICBqdXN0aWZ5LWNvbnRlbnQ6IGNlbnRlcjtcbiAgICAgICAgICAgIGEge1xuICAgICAgICAgICAgICAgIGNvbG9yOiBibGFjaztcbiAgICAgICAgICAgICAgICBmb250LXdlaWdodDogYm9sZDtcbiAgICAgICAgICAgICAgICBmb250LXNpemU6IDEuNmVtO1xuICAgICAgICAgICAgICAgIHRleHQtZGVjb3JhdGlvbjogbm9uZTtcbiAgICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgIH1cbn1cbiIsIu+7v0BtaXhpbiBjbGVhcmZpeCB7XG4gICAgJjphZnRlciB7XG4gICAgICAgIGNvbnRlbnQ6IFwiXCI7XG4gICAgICAgIGRpc3BsYXk6IHRhYmxlO1xuICAgICAgICBjbGVhcjogYm90aDtcbiAgICB9XG59XG4iXSwic291cmNlUm9vdCI6Ii9zb3VyY2UvIn0= */

--- a/css/a-z-listing-default.scss
+++ b/css/a-z-listing-default.scss
@@ -1,20 +1,30 @@
 @import "mixins.scss";
 
-.a-z-listing-widget.default-style {
-    .letter {
-        .az-letters {
-            @include clearfix();
-            ul.az-links {
-                li {
-                    float: left;
-                    width: 2em;
-                    height: 2em;
-                    box-sizing: border-box;
-                    margin: 0.15em;
-                    border: 1px solid #8bf;
-                    background: #adf;
-                    color: black;
-                }
+.az-letters {
+    @include clearfix();
+    display: flex;
+    justify-content: center;
+    ul.az-links {
+        padding: 0;
+        margin: 0;
+        li {
+            list-style: none;
+            float: left;
+            width: 2em;
+            height: 2em;
+            box-sizing: border-box;
+            margin: 0.15em;
+            border: 1px solid #8bf;
+            background: #adf;
+            color: black;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            a {
+                color: black;
+                font-weight: bold;
+                font-size: 1.6em;
+                text-decoration: none;
             }
         }
     }

--- a/functions/common/resources.php
+++ b/functions/common/resources.php
@@ -1,6 +1,6 @@
 <?php
 if ( ! function_exists( 'bh_select_post_id' ) ) {
-	function select_post_id( $p = null ) {
+	function bh_select_post_id( $p = null ) {
 		if ( is_null( $p ) ) {
 			global $post;
 			$p = $post;

--- a/partials/az-styling.php
+++ b/partials/az-styling.php
@@ -1,12 +1,15 @@
 <?php
 
 function a_z_listing_enqueue_styles() {
-	wp_enqueue_style( 'a-z-listing', dirname( __FILE__ ) . '/../css/a-z-listing-default.css' );
+	$url = plugins_url( 'css/a-z-listing-default.css', dirname( __FILE__ ) );
+	wp_enqueue_style( 'a-z-listing', $url );
 }
 
 function a_z_listing_add_styling() {
-	if ( true === get_option( 'a-z-listing-add-styling' ) ) {
-		add_action( 'wp-enqueue-scripts', 'a_z_listing_enqueue_styles' );
+	$add_styles = apply_filters( 'a-z-listing-add-styling', get_option( 'a-z-listing-add-styling' ) );
+	do_action( 'log', 'A-Z Listing: Add Styles', $add_styles );
+	if ( true === $add_styles ) {
+		add_action( 'wp_enqueue_scripts', 'a_z_listing_enqueue_styles' );
 	}
 }
 add_action( 'init', 'a_z_listing_add_styling' );

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: diddledan
 Tags: a to z, a-z, archive, listing, widget, index
 Requires at least: 3.5
-Tested up to: 4.4
-Stable tag: 0.7.2
+Tested up to: 4.5
+Stable tag: 0.8.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -41,7 +41,7 @@ placing the a-z index on a child of section1 will likewise limit the index page 
 Likewise for section2, section2a and section2b.
 
 = NOTE =
-Styling (CSS) is left entirely up to the developer or site owner.
+Styling (CSS) is *off* by default. See the FAQ section for details to turn-on in-built styles.
 
 == Installation ==
 
@@ -50,7 +50,7 @@ This section describes how to install the plugin and get it working.
 1. Upload the `a-z-listing` folder to the `/wp-content/plugins/` directory
 1. Activate the plugin through the 'Plugins' menu in WordPress
 1. Place `<?php the_az_listing(); ?>` in your templates for the index page output or use the `a-z-listing` shortcode.
-1. Add the A-Z Site Map widget to a sidebar or use `<?php the_az_widget(null, array('post' => get_page($id))); ?>` in your templates (the 'post' variable indicates where the A-Z Index page is located).
+1. Add the A-Z Site Map widget to a sidebar or use `<?php the_a_z_widget(null, array('post' => get_page($id))); ?>` in your templates (the 'post' variable indicates where the A-Z Index page is located).
 
 == Shortcode ==
 
@@ -76,13 +76,22 @@ The theme system this plugin implements is very similar to the standard WordPres
 
 Important functions to use in your template are as follows:
 
-* `the_az_letters()` outputs the full alphabet, and links the letters that have posts to their section within the index page.
+* `the_a_z_letters()` outputs the full alphabet, and links the letters that have posts to their section within the index page.
 * `have_a_z_letters()` returns true or false depending on whether there are any letters left to loop-through. This is part of the Letter Loop.
-* `have_a_z_posts()` this behaves very similarly to Core's `have_posts()` function. It is part of the Post Loop.
-* `the_a_z_letter()` similar to Core's `the_post`, this will set-up the next iteration of the A-Z Listing's Letter Loop. This needs to wrap-around the Post Loop.
-* `the_a_z_post()` similar to Core's `the_post`, this will set-up the next iteration of the A-Z Listing's _Post_ Loop. This needs to be _within_ the Letter Loop.
+* `have_a_z_items()` this behaves very similarly to Core's `have_posts()` function. It is part of the Item Loop.
+* `the_a_z_letter()` similar to Core's `the_post`, this will set-up the next iteration of the A-Z Listing's Letter Loop. This needs to wrap-around the Item Loop.
+* `the_a_z_item()` similar to Core's `the_post`, this will set-up the next iteration of the A-Z Listing's Item Loop, the same way the normal WordPress Loop works. This needs to be _within_ the Letter Loop.
 
 When you are within the Post Loop you can utilise all in-built WordPress Core post-related functions such as `the_title()`, `the_permalink`, `the_content`, etc.
+
+= Helper functions =
+
+In 0.8.0 we added taxonomy-terms listings to the featureset. This means that the WordPress functions related to posts such as `the_title` and `the_permalink` are unreliable. We have therefore added helper functions which will return or print the correct output for the item.
+
+These helper functions cope with the duality of the plugin supporting both WP_Query-based and Taxonomy Terms listings. These are:
+
+* `the_a_z_item_title()` - returns the current item's Title
+* `the_a_z_item_permalink()` returns the current item's Permalink
 
 == Frequently Asked Questions ==
 
@@ -91,13 +100,21 @@ When you are within the Post Loop you can utilise all in-built WordPress Core po
 in your theme's functions.php add the following code:
 
     <?php
-    add_filter('az_sections', 'remove_az_section_targeting');
-    function remove_az_section_targeting($sections) {
+    add_filter('a-z-listing-sections', 'remove_a_z_section_targeting');
+    function remove_a_z_section_targeting($sections) {
         return array();
     }
     ?>
 
 This filter can also be used, by removing entries which are standard $post variables, to limit which top-level pages are used as section identifiers.
+
+= How do I apply the in-built styling? =
+
+in your theme's functions.php add the following code:
+
+    <?php
+    add_filter( 'a-z-listing-add-styling', '__return_true' );
+    ?>
 
 == Screenshots ==
 
@@ -105,6 +122,13 @@ This filter can also be used, by removing entries which are standard $post varia
 2. The Widget is shown here.
 
 == Changelog ==
+
+= 0.8.0 =
+* Standardised on naming convention of *_a_z_* in function names, e.g. `get_the_a_z_listing()`, rather than the former *_az_* names, e.g. `get_the_az_listing()`.
+* Converted version numbering to semver style.
+* Fixed the in-built styling.
+* Added filter to determine whether to apply in-built styles in addition to hidden setting: `set_option( a-z-listing-add-styling', true );`.
+* Added taxonomy terms list support.
 
 = 0.7.1 =
 * Fix potential XSS vector.

--- a/templates/a-z-listing.php
+++ b/templates/a-z-listing.php
@@ -1,14 +1,14 @@
 <?php global $_a_z_listing_colcount, $_a_z_listing_minpercol; ?>
 <div id="letters">
 	<div class="az-letters">
-		<?php the_az_letters(); ?><div class="clear empty"></div>
+		<?php the_a_z_letters(); ?><div class="clear empty"></div>
 	</div>
 </div>
 <?php if ( have_a_z_letters() ) : ?>
 <div id="az-slider">
 	<div id="inner-slider">
 		<?php while ( have_a_z_letters() ) : the_a_z_letter(); ?>
-			<?php if ( have_a_z_posts() ) : ?>
+			<?php if ( have_a_z_items() ) : ?>
 				<div class="letter-section" id="<?php the_a_z_letter_id(); ?>">
 					<a name="<?php the_a_z_letter_id(); ?>"></a>
 					<h2>
@@ -16,13 +16,13 @@
 					</h2>
 					<?php $i = $j = 0; ?>
 					<?php $numpercol = ceil( num_a_z_posts() / $_a_z_listing_colcount ); ?>
-					<?php while ( have_a_z_posts() ) : the_a_z_post(); ?>
+					<?php while ( have_a_z_items() ) : the_a_z_item(); ?>
 						<?php if ( 0 === $i++ ) : ?>
 							<div><ul>
 						<?php endif; ?>
 						<?php $j++; ?>
 						<li>
-							<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+							<a href="<?php the_permalink(); ?>"><?php the_a_z_item_title(); ?></a>
 						</li>
 						<?php if ( ( $_a_z_listing_minpercol - $i <= 0 && $numpercol - $i <= 0 ) || num_a_z_posts() <= $j ) : ?>
 							</ul></div>

--- a/tests/test-listing.php
+++ b/tests/test-listing.php
@@ -1,32 +1,32 @@
 <?php
 class AZ_Listing_Tests extends WP_UnitTestCase {
 	function test_empty_letters() {
-		$letters = get_the_az_letters();
+		$letters = get_the_a_z_letters();
 		$this->assertStringEqualsFile( 'tests/default-letters.txt', $letters );
 	}
 	function test_empty_listing() {
-		$listing = get_the_az_listing();
+		$listing = get_the_a_z_listing();
 		$this->assertStringEqualsFile( 'tests/default-listing.txt', $listing );
 	}
 
 	function test_populated_letters() {
 		$p = $this->factory->post->create( array( 'post_title' => 'Test Page', 'post_type' => 'page' ) );
 		$q = new WP_Query( array( 'post_type' => 'page' ) );
-		$letters = get_the_az_letters( $q );
+		$letters = get_the_a_z_letters( $q );
 		$this->assertStringEqualsFile( 'tests/populated-letters.txt', $letters );
 	}
 
 	function test_populated_letters_linked() {
 		$p = $this->factory->post->create( array( 'post_title' => 'Test Page', 'post_type' => 'page' ) );
 		$q = new WP_Query( array( 'post_type' => 'page' ) );
-		$letters = get_the_az_letters( $q, '/test-path' );
+		$letters = get_the_a_z_letters( $q, '/test-path' );
 		$this->assertStringEqualsFile( 'tests/populated-letters-linked.txt', $letters );
 	}
 
 	function test_populated_listing() {
 		$p = $this->factory->post->create( array( 'post_title' => 'Test Page', 'post_type' => 'page' ) );
 		$q = new WP_Query( array( 'post_type' => 'page' ) );
-		$listing = get_the_az_listing( $q );
+		$listing = get_the_a_z_listing( $q );
 		$expected = sprintf( file_get_contents( 'tests/populated-listing.txt' ), $p );
 		$this->assertEquals( $expected, $listing );
 	}

--- a/tests/test-widget.php
+++ b/tests/test-widget.php
@@ -3,7 +3,7 @@ class AZ_Widget_Tests extends WP_UnitTestCase {
 	function test_widget() {
 		$p = $this->factory->post->create( array( 'post_title' => 'Index Page', 'post_type' => 'page' ) );
 		$this->expectOutputString( sprintf( file_get_contents( 'tests/default-widget.txt' ), $p ) );
-		the_section_az_widget(
+		the_section_a_z_widget(
 			array(
 				'before_widget' => '<div>',
 				'after_widget' => '</div>',
@@ -20,7 +20,7 @@ class AZ_Widget_Tests extends WP_UnitTestCase {
 		$p = $this->factory->post->create( array( 'post_title' => 'Index Page', 'post_type' => 'page' ) );
 		$p2 = $this->factory->post->create( array( 'post_title' => 'Test Post', 'post_type' => 'page' ) );
 		$this->expectOutputString( sprintf( file_get_contents( 'tests/populated-widget.txt' ), $p ) );
-		the_section_az_widget(
+		the_section_a_z_widget(
 			array(
 				'before_widget' => '<div>',
 				'after_widget' => '</div>',

--- a/widgets/a-z-widget.php
+++ b/widgets/a-z-widget.php
@@ -7,7 +7,7 @@
 /**
  * Definition for the AZ_Widget which displays alphabetically-ordered list of latin letters linking to the A-Z Listing page.
  */
-class AZ_Widget extends WP_Widget {
+class A_Z_Widget extends WP_Widget {
 	/**
 	 * Register the widget's meta information.
 	 */
@@ -29,7 +29,7 @@ class AZ_Widget extends WP_Widget {
 	/**
 	 * Deprecated constructor.
 	 */
-	function AZ_Widget() {
+	function A_Z_Widget() {
 		$this->__construct();
 	}
 
@@ -48,43 +48,43 @@ class AZ_Widget extends WP_Widget {
 	 */
 	function form( $instance ) {
 		$title = $instance['title'];
-		$titleID = $this->get_field_id( 'title' );
-		$titleName = $this->get_field_name( 'title' );
+		$title_ID = $this->get_field_id( 'title' );
+		$title_name = $this->get_field_name( 'title' );
 
 		$post = isset( $instance['post'] ) ? $instance['post'] : ( isset( $instance['page'] ) ? $instance['page'] : 0 );
-		$postID = $this->get_field_id( 'post' );
-		$postName = $this->get_field_name( 'post' );
+		$post_ID = $this->get_field_id( 'post' );
+		$post_name = $this->get_field_name( 'post' );
 
-		$stylingChecked = isset( $instance['apply-styling'] ) ? (bool) $instance['apply-styling'] : false;
-		$stylingID = $this->get_field_id( 'apply-styling' );
-		$stylingName = $this->get_field_name( 'apply-styling' );
+		$styling_checked = isset( $instance['apply-styling'] ) ? (bool) $instance['apply-styling'] : false;
+		$styling_ID = $this->get_field_id( 'apply-styling' );
+		$styling_name = $this->get_field_name( 'apply-styling' );
 
 		?>
-		<div><label for="<?php echo esc_attr( $postID ); ?>">
+		<div><label for="<?php echo esc_attr( $post_ID ); ?>">
 			<?php esc_html_e( 'Site map A-Z page', 'a-z-listing' ); ?>
 		</label></div>
 		<?php
 		wp_dropdown_pages(array(
-			'id' => intval( $postID ),
-			'name' => esc_html( $postName ),
+			'id' => intval( $post_ID ),
+			'name' => esc_html( $post_name ),
 			'selected' => intval( $post ),
 		));
 		?>
-		<div><label for="<?php echo esc_attr( $titleID ); ?>">
+		<div><label for="<?php echo esc_attr( $title_ID ); ?>">
 			<?php esc_html_e( 'Widget Title', 'a-z-listing' ); ?>
 		</label></div>
 		<input class="widefat" type="text"
-				id="<?php echo esc_attr( $titleID ); ?>"
-				name="<?php echo esc_attr( $titleName ); ?>"
+				id="<?php echo esc_attr( $title_ID ); ?>"
+				name="<?php echo esc_attr( $title_name ); ?>"
 				placeholder="<?php esc_attr_e( 'Widget Title', 'a-z-listing' ); ?>"
 				value="<?php echo esc_attr( $title ); ?>" />
 		<p style="color: #333;">
 			<?php esc_html_e( 'Leave blank to use the title specified by the page', 'a-z-listing' ); ?>
 		</p>
-        <input type="checkbox"
-                id="<?php echo esc_attr( $stylingID ); ?>"
-                name="<?php echo esc_attr( $stylingName ); ?>"
-                <?php if ( true === $stylingChecked ) : ?> checked <?php endif; ?> />
+		<input type="checkbox"
+			id="<?php echo esc_attr( $styling_ID ); ?>"
+			name="<?php echo esc_attr( $styling_name ); ?>"
+			<?php if ( true === $styling_checked ) : ?> checked <?php endif; ?> />
 		<?php
 	}
 
@@ -112,21 +112,33 @@ class AZ_Widget extends WP_Widget {
 }
 
 /**
+ * @deprecated in favour of the_section_a_z_widget
+ */
+function the_section_az_widget( $args, $instance ) {
+	the_section_a_z_widget( $args, $instance );
+}
+/**
  * Print the user-visible widget to the page implentation.
  * @param  Array $args     General widget configuration. Often shared between all widgets on the site.
  * @param  Array $instance Configuration of this Widget. Unique to this invocation.
  */
-function the_section_az_widget( $args, $instance ) {
+function the_section_a_z_widget( $args, $instance ) {
 	echo get_the_section_az_widget( $args, $instance ); // WPCS: XSS OK.
 }
 
+/**
+ * @deprecated in favour of get_the_section_a_z_widget()
+ */
+function get_the_section_az_widget( $args, $instance ) {
+	return get_the_section_a_z_widget( $args, $instance );
+}
 /**
  * Get the user-visible widget html.
  * @param  Array $args     General widget configuration. Often shared between all widgets on the site.
  * @param  Array $instance Configuration of this Widget. Unique to this invocation.
  * @return  string The complete A-Z Widget HTML ready for echoing to the page.
  */
-function get_the_section_az_widget( $args, $instance ) {
+function get_the_section_a_z_widget( $args, $instance ) {
 	extract( $args );
 
 	$instance = wp_parse_args( $instance, array(


### PR DESCRIPTION
- Standardised on naming convention of *_a_z_* in function names, e.g. `get_the_a_z_listing()`, rather than the former *_az_* names, e.g. `get_the_az_listing()`.
- Converted version numbering to semver style.
- Fixed the in-built styling.
- Added filter to determine whether to apply in-built styles in addition to hidden setting: `set_option( a-z-listing-add-styling', true );`.
- Added taxonomy terms list support.