### PR TITLE
Bugfix: Lower case titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 **Contributors:** diddledan
 **Tags:** a to z, a-z, archive, listing, widget, index
 **Requires at least:** 3.5
-**Tested up to:** 4.6.1
-**Stable tag:** 1.0.0
+**Tested up to:** 4.7.0
+**Stable tag:** 1.1.0
 **License:** GPLv2 or later
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -129,6 +129,9 @@ in your theme's functions.php add the following code:
 ![2. The Widget is shown here.](http://ps.w.org/a-to-z-index/assets/screenshot-2.png)
 
 ## Changelog ##
+
+### 1.0.1 ###
+* BUGFIX: lower-case titles missing
 
 ### 1.0.0 ###
 * BREAKING CHANGE: Refactored several function names. If you have written your own template/loop you will need to adapt your code. See the readme.txt's Theming section for details.

--- a/a-z-listing.php
+++ b/a-z-listing.php
@@ -11,6 +11,9 @@
  * @package  a-z-listing
  */
 
+if ( ! defined('AZLISTINGLOG') ) {
+	define( 'AZLISTINGLOG', false );
+}
 /**
  * Called on plugin activation. Includes any php files in ./activate/.
  */

--- a/a-z-listing.php
+++ b/a-z-listing.php
@@ -11,7 +11,7 @@
  * @package  a-z-listing
  */
 
-if ( ! defined('AZLISTINGLOG') ) {
+if ( ! defined( 'AZLISTINGLOG' ) ) {
 	define( 'AZLISTINGLOG', false );
 }
 /**

--- a/partials/a-z-listing.class.php
+++ b/partials/a-z-listing.class.php
@@ -35,13 +35,19 @@ class A_Z_Listing {
 		$this->available_indices = array_values( array_unique( array_values( self::$alphabet ) ) );
 
 		if ( is_string( $query ) && ! empty( $query ) ) {
-			if (AZLISTINGLOG) do_action( 'log', 'A-Z Listing: Setting taxonomy mode', $query );
+			if (AZLISTINGLOG) {
+				do_action( 'log', 'A-Z Listing: Setting taxonomy mode', $query );
+			}
 			$this->type = 'taxonomy';
 			$this->taxonomy = $query;
 			$this->items = get_terms( $query, array( 'hide_empty' => false ) );
-			if (AZLISTINGLOG) do_action( 'log', 'A-Z Listing: Terms', '!slug', $this->items );
+			if (AZLISTINGLOG) {
+				do_action( 'log', 'A-Z Listing: Terms', '!slug', $this->items );
+			}
 		} else {
-			if (AZLISTINGLOG) do_action( 'log', 'A-Z Listing: Setting posts mode', $query );
+			if (AZLISTINGLOG) {
+				do_action( 'log', 'A-Z Listing: Setting posts mode', $query );
+			}
 			$index_taxonomy = apply_filters( 'az_additional_titles_taxonomy', '' );
 			$this->index_taxonomy = apply_filters( 'a_z_listing_additional_titles_taxonomy', $index_taxonomy );
 
@@ -103,7 +109,9 @@ class A_Z_Listing {
 		if ( ! in_array( $section, $sections, true ) ) {
 			$section = null;
 		}
-		if (AZLISTINGLOG) do_action( 'log', 'A-Z Section', $section );
+		if (AZLISTINGLOG) {
+			do_action( 'log', 'A-Z Section', $section );
+		}
 		return $section;
 	}
 
@@ -158,7 +166,9 @@ class A_Z_Listing {
 
 		$indices = apply_filters( 'a_z_listing_post_indices', $indices, $item );
 		$indices = apply_filters( 'a_z_listing_item_indices', $indices, $item, $this->type );
-		if (AZLISTINGLOG) do_action( 'log', 'Item indices', $indices );
+		if (AZLISTINGLOG) {
+			do_action( 'log', 'Item indices', $indices );
+		}
 		return $indices;
 	}
 

--- a/partials/az-styling.php
+++ b/partials/az-styling.php
@@ -7,7 +7,9 @@ function a_z_listing_enqueue_styles() {
 
 function a_z_listing_add_styling() {
 	$add_styles = apply_filters( 'a_z_listing_add_styling', get_option( 'a-z-listing-add-styling' ) );
-	if (AZLISTINGLOG) do_action( 'log', 'A-Z Listing: Add Styles', $add_styles );
+	if (AZLISTINGLOG) {
+		do_action( 'log', 'A-Z Listing: Add Styles', $add_styles );
+	}
 	if ( true === $add_styles ) {
 		add_action( 'wp_enqueue_scripts', 'a_z_listing_enqueue_styles' );
 	}

--- a/partials/az-styling.php
+++ b/partials/az-styling.php
@@ -7,7 +7,7 @@ function a_z_listing_enqueue_styles() {
 
 function a_z_listing_add_styling() {
 	$add_styles = apply_filters( 'a_z_listing_add_styling', get_option( 'a-z-listing-add-styling' ) );
-	do_action( 'log', 'A-Z Listing: Add Styles', $add_styles );
+	if (AZLISTINGLOG) do_action( 'log', 'A-Z Listing: Add Styles', $add_styles );
 	if ( true === $add_styles ) {
 		add_action( 'wp_enqueue_scripts', 'a_z_listing_enqueue_styles' );
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: diddledan
 Tags: a to z, a-z, archive, listing, widget, index
 Requires at least: 3.5
-Tested up to: 4.6.1
-Stable tag: 1.0.0
+Tested up to: 4.7.0
+Stable tag: 1.1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -188,6 +188,9 @@ in your theme's functions.php add the following code:
 2. The Widget is shown here.
 
 == Changelog ==
+
+= 1.0.1 =
+* BUGFIX: lower-case titles missing
 
 = 1.0.0 =
 * BREAKING CHANGE: Refactored several function names. If you have written your own template/loop you will need to adapt your code. See the readme.txt's Theming section for details.

--- a/readme.txt
+++ b/readme.txt
@@ -41,6 +41,7 @@ placing the a-z index on a child of section1 will likewise limit the index page 
 Likewise for section2, section2a and section2b.
 
 = NOTE =
+
 Styling (CSS) is *off* by default. See the FAQ section for details to turn-on in-built styles.
 
 == Installation ==
@@ -49,65 +50,126 @@ This section describes how to install the plugin and get it working.
 
 1. Upload the `a-z-listing` folder to the `/wp-content/plugins/` directory
 1. Activate the plugin through the 'Plugins' menu in WordPress
-1. Place `<?php the_az_listing(); ?>` in your templates for the index page output or use the `a-z-listing` shortcode.
-1. Add the A-Z Site Map widget to a sidebar or use `<?php the_a_z_widget(null, array('post' => get_page($id))); ?>` in your templates (the 'post' variable indicates where the A-Z Index page is located).
+1. Place `<?php the_a_z_listing(); ?>` in your templates for the index page output (see the **php** section of this document for details) or use the `a-z-listing` shortcode (see the **shortcode** section of this document for details).
+1. Add the A-Z Site Map widget to a sidebar or use `<?php the_a_z_widget( null, array( 'post' => get_page( $id ) ) ); ?>` in your templates (see the **php** section of this document for details).
 
 == Shortcode ==
 
-New for 0.5 is a shortcode for the full A-Z listing allowing use without modifying your theme's templates.
+The plugin supplies a shortcode for the full A-Z listing allowing use without modifying your theme's templates.
 
-The usage is as follows:
+Basic usage is as follows:
 
-    [a-z-listing column-count=1 minimum-per-column=10 heading-level=2]
+    [a-z-listing]
 
-The arguments are all optional with their defaults shown above, which will be used when omitted.
+To specify a post-type to display instead of "page" then use:
 
+    [a-z-listing post-type=my-post-type]
+
+If you are using the multi-column example template (see below for details on using the template) then you can specify the following options:
+
+    [a-z-listing post-type=my-post-type column-count=1 minimum-per-column=10 heading-level=2]
+
+The arguments are all optional.
+
+* `post-type` sets the listing to show a specific post-type.
+  * default value: page
 * `column-count` defines how many columns of titles you want displayed for each alphabet letter.
+  * default value: 1
 * `minimum-per-column` is used to indicate the breakpoint number of posts before using an additional column. This prevents situations such as specifying 3 columns but having only three posts for a particular letter causing one post to be shown in each of the three columns. When using this feature we will keep all three posts in the first column even though we have also specified to use three columns because three is less-than the ten we set as the minimum breakpoint. Once the breakpoint is reached the columns will grow together.
+  * default value: 10
 * `heading-level` tells the code what HTML "heading number" to use, e.g. h1, h2, h3 etc. This is primarily to allow you to set things for correct accessibility as this plugin cannot anticipate how different themes will set-up their heading structure.
+  * default value: 2
 
-== Theming ==
+= Multi Column Output =
 
-New for 0.7 is themeability! This allows the site owner or theme developer to provide custom templates for the A-Z Listing output.
+If you want the multi-column output support, you need to copy the file `a-z-listing-multi-column.example.php` from the plugin inside the `templates` directory to your theme. The file needs to also be renamed to `a-z-listing.php` when copied to your theme. The **Templates and Theming** section of this Document details the functions used within templates and The Loop process this plugin follows.
+
+== Templates and Theming ==
+
+The plugin allows the site owner, developer, or themer to provide custom templates for the A-Z Listing output.
 
 *NOTE: These functions have changed name and method of access in 1.0.0. We have dropped the _a_z_ moniker in the function name and within the template file they are accessed via the `$a_z_listing` object.* The former function names are still accessible, but are largely deprecated.
 
 To add a template to your theme, you need a file similar to the `templates/a-z-listing.php` file in the plugin folder. Your copy needs to be placed within your theme at the theme root directory and called `a-z-listing.php` or `a-z-listing-section.php` (where `-section` is an optional top-level page slug for the section-targeting feature).
 
-The theme system this plugin implements is very similar to the standard WordPress loop, with a few added bits.
+= The Loop =
+
+The theme system this plugin implements is *very* similar to the standard WordPress loop, with a few added bits.
 
 Important functions to use in your template are as follows:
 
 * `$a_z_query->the_letters()` prints the full alphabet, and links the letters that have posts to their section within the index page.
 * `$a_z_query->have_letters()` returns true or false depending on whether there are any letters left to loop-through. This is part of the Letter Loop.
 * `$a_z_query->have_items()` this behaves very similarly to Core's `have_posts()` function. It is part of the Item Loop.
-* `$a_z_query->the_letter()` similar to Core's `the_post`, this will set-up the next iteration of the A-Z Listing's Letter Loop. This needs to wrap-around the Item Loop.
-* `$a_z_query->the_item()` similar to Core's `the_post`, this will set-up the next iteration of the A-Z Listing's Item Loop, the same way the normal WordPress Loop works. This needs to be _within_ the Letter Loop.
+* `$a_z_query->the_letter()` similar to Core's `the_post()`, this will set-up the next iteration of the A-Z Listing's Letter Loop. This needs to wrap-around the Item Loop.
+* `$a_z_query->the_item()` similar to Core's `the_post()`, this will set-up the next iteration of the A-Z Listing's Item Loop, the same way the normal WordPress Loop works. This needs to be _within_ the Letter Loop.
 
-When you are within the Item Loop you can utilise all in-built WordPress Core post-related functions such as `the_content`. Note that titles and permalinks have helper functions to cope with the A-Z Listing showing taxonomy terms (see the next section).
+When you are within the Item Loop you can utilise all in-built WordPress Core post-related functions such as `the_content()`. Note that titles and permalinks have helper functions to cope with the A-Z Listing showing taxonomy terms (see the next section).
+
+I advise that you start with a copy of the default template or the multi-column template when customizing your own version. The supplied templates show the usage of most of the functions this plugin provides.
 
 = Helper functions =
 
-In 0.8.0 we added taxonomy-terms listings to the featureset. This means that the WordPress functions related to posts such as `the_title` and `the_permalink` are unreliable. We have therefore added helper functions which will return or print the correct output for the item.
+In 0.8.0 we added taxonomy-terms listings to the plugin. This means that the WordPress functions related to posts such as `the_title()` and `the_permalink()` are unreliable. We have therefore added helper functions which will return or print the correct output for the item.
 
-*NOTE: These functions have changed name and method of access in 1.0.0. We have dropped the _a_z_ moniker in the function name and within the template file they are accessed via the `$a_z_listing` object.* The former function names are still accessible, but are largely deprecated.
+*NOTE: These functions have changed name and method of access in 1.0.0. We have dropped the _a_z_ moniker in the function name and within the template file they are accessed via the `$a_z_listing` object.* The previous function names are still accessible, but are largely deprecated.
 
-These helper functions cope with the duality of the plugin supporting both `WP_Query`-based (returning `WP_Post` objects) and Taxonomy Terms (returning `WP_Term` objects) listings. These are:
+These helper functions cope with the dual usage of the plugin supporting both `WP_Query`-based (returning `WP_Post` objects) and Taxonomy Terms (returning `WP_Term` objects) listings. These are:
 
 * `$a_z_query->the_title()` - prints the current item's Title
+* `$a_z_query->get_the_title()` returns the current item's Title but does not print it directly
 * `$a_z_query->the_permalink()` prints the current item's Permalink
+* `$a_z_query->get_the_permalink()` returns the current item's Permalink but does not print it directly
 
 == Frequently Asked Questions ==
+
+= How do I show posts of a different post-type =
+
+This can be achieved using the shortcode or PHP.
+
+*Shortcode method*
+
+[a-z-listing post-type=your-post-type-slug]
+
+*PHP method*
+
+PHP code needs to be added to your theme files, and cannot be used as post or page content in the way that a shortcode can.
+
+    <?php
+    the_a_z_listing( array(
+        'post_type' => 'your-post-type-slug'
+    ) );
+    ?>
+
+The argument to `the_a_z_listing()` is an [http://php.net/manual/en/language.types.array.php](array) and takes the same parameters as [https://codex.wordpress.org/Class_Reference/WP_Query](WP_Query)
+
+= How do I show posts from a specific category only =
+
+This can only be done via PHP and cannot currently be achieved using the shortcode.
+
+*PHP method*
+
+PHP code needs to be added to your theme files, and cannot be used as post or page content in the way that a shortcode can.
+
+    <?php
+    the_a_z_listing( array(
+        'tax_query' => array(
+            'taxonomy' => 'your-taxonomy-slug',
+            'terms' => array( 'term1-slug', 'term2-slug' )
+        )
+    ) );
+    ?>
+
+Any number of terms can be added to the `terms` [http://php.net/manual/en/language.types.array.php](array), including one or none.
+
+The argument to `the_a_z_listing()` is an [http://php.net/manual/en/language.types.array.php](array) and takes the same parameters as [https://codex.wordpress.org/Class_Reference/WP_Query](WP_Query)
 
 = How do I remove section targetting or limit which sections are available? =
 
 in your theme's functions.php add the following code:
 
     <?php
-    add_filter('a-z-listing-sections', 'remove_a_z_section_targeting');
-    function remove_a_z_section_targeting($sections) {
-        return array();
-    }
+    add_filter( 'a-z-listing-sections', '__return_empty_array' );
     ?>
 
 This filter can also be used, by removing entries which are standard $post variables, to limit which top-level pages are used as section identifiers.


### PR DESCRIPTION
reference: https://wordpress.org/support/topic/lowercase-post-titles-2/

Lower-cased titles were being hidden from display. This fixes that.