### PR TITLE
tests for lowercased titles

### DIFF
--- a/tests/populated-listing-lowercase.txt
+++ b/tests/populated-listing-lowercase.txt
@@ -1,0 +1,41 @@
+<div id="letters">
+    <div class="az-letters">
+        <ul class="az-links">
+            <li class="first odd"><span>A</span></li>
+            <li class="even"><span>B</span></li>
+            <li class="odd"><span>C</span></li>
+            <li class="even"><span>D</span></li>
+            <li class="odd"><span>E</span></li>
+            <li class="even"><span>F</span></li>
+            <li class="odd"><span>G</span></li>
+            <li class="even"><span>H</span></li>
+            <li class="odd"><span>I</span></li>
+            <li class="even"><span>J</span></li>
+            <li class="odd"><span>K</span></li>
+            <li class="even"><span>L</span></li>
+            <li class="odd"><span>M</span></li>
+            <li class="even"><span>N</span></li>
+            <li class="odd"><span>O</span></li>
+            <li class="even"><span>P</span></li>
+            <li class="odd"><span>Q</span></li>
+            <li class="even"><span>R</span></li>
+            <li class="odd"><span>S</span></li>
+            <li class="even"><a href="#letter-T"><span>T</span></a></li>
+            <li class="odd"><span>U</span></li>
+            <li class="even"><span>V</span></li>
+            <li class="odd"><span>W</span></li>
+            <li class="even"><span>X</span></li>
+            <li class="odd"><span>Y</span></li>
+            <li class="last even"><span>Z</span></li>
+        </ul>
+        <div class="clear empty"></div>
+    </div>
+</div>
+<div id="az-slider">
+    <div id="inner-slider"><div class="letter-section" id="letter-T">
+        <h2><span>T</span></h2>
+        <div><ul>
+            <li><a href="http://example.org/?page_id=%d">test page</a></li>
+        </ul></div>
+    </div></div>
+</div>

--- a/tests/test-listing.php
+++ b/tests/test-listing.php
@@ -52,4 +52,40 @@ class AZ_Listing_Tests extends WP_UnitTestCase {
 		$actual = preg_replace( '/\s{2,}|\t|\n/', '', $actual );
 		$this->assertEquals( $expected, $actual );
 	}
+
+	function test_populated_lowercase_letters() {
+		$p = $this->factory->post->create( array( 'post_title' => 'test page', 'post_type' => 'page' ) );
+		$q = new WP_Query( array( 'post_type' => 'page' ) );
+
+		$expected = file_get_contents( 'tests/populated-letters.txt' );
+		$actual = get_the_a_z_letters( $q );
+
+		$expected = preg_replace( '/\s{2,}|\t|\n/', '', $expected );
+		$actual = preg_replace( '/\s{2,}|\t|\n/', '', $actual );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	function test_populated_lowercase_letters_linked() {
+		$p = $this->factory->post->create( array( 'post_title' => 'test page', 'post_type' => 'page' ) );
+		$q = new WP_Query( array( 'post_type' => 'page' ) );
+
+		$expected = file_get_contents( 'tests/populated-letters-linked.txt' );
+		$actual = get_the_a_z_letters( $q, '/test-path' );
+
+		$expected = preg_replace( '/\s{2,}|\t|\n/', '', $expected );
+		$actual = preg_replace( '/\s{2,}|\t|\n/', '', $actual );
+		$this->assertEquals( $expected, $actual );
+	}
+
+	function test_populated_lowercase_listing() {
+		$p = $this->factory->post->create( array( 'post_title' => 'test page', 'post_type' => 'page' ) );
+		$q = new WP_Query( array( 'post_type' => 'page' ) );
+
+		$expected = sprintf( file_get_contents( 'tests/populated-listing-lowercase.txt' ), $p );
+		$actual = get_the_a_z_listing( $q );
+
+		$expected = preg_replace( '/\s{2,}|\t|\n/', '', $expected );
+		$actual = preg_replace( '/\s{2,}|\t|\n/', '', $actual );
+		$this->assertEquals( $expected, $actual );
+	}
 }

--- a/tests/test-shortcode.php
+++ b/tests/test-shortcode.php
@@ -19,4 +19,15 @@ class AZ_Shortcode_Tests extends WP_UnitTestCase {
 		$actual = preg_replace( '/\s{2,}|\t|\n/', '', $actual );
 		$this->assertEquals( $expected, $actual );
 	}
+
+	function test_populated_lowercase_titles() {
+		$p = $this->factory->post->create( array( 'post_title' => 'test page', 'post_type' => 'page' ) );
+
+		$expected = sprintf( file_get_contents( 'tests/populated-listing-lowercase.txt' ), $p );
+		$actual = do_shortcode( '[a-z-listing]' );
+
+		$expected = preg_replace( '/\s{2,}|\t|\n/', '', $expected );
+		$actual = preg_replace( '/\s{2,}|\t|\n/', '', $actual );
+		$this->assertEquals( $expected, $actual );
+	}
 }

--- a/tests/test-widget.php
+++ b/tests/test-widget.php
@@ -43,4 +43,27 @@ class AZ_Widget_Tests extends WP_UnitTestCase {
 			)
 		);
 	}
+
+	function test_populated_widget_lowercase_titles() {
+		$p = $this->factory->post->create( array( 'post_title' => 'Index Page', 'post_type' => 'page' ) );
+		$p2 = $this->factory->post->create( array( 'post_title' => 'test post', 'post_type' => 'page' ) );
+
+		$expected = sprintf( file_get_contents( 'tests/populated-widget.txt' ), $p );
+		$expected = preg_replace( '/\s{2,}|\t|\n/', '', $expected );
+
+		$this->expectOutputString( $expected );
+
+		the_section_a_z_widget(
+			array(
+				'before_widget' => '<div>',
+				'after_widget' => '</div>',
+				'before_title' => '<h2>',
+				'after_title' => '</h2>',
+			),
+			array(
+				'title' => 'Test Widget',
+				'post' => $p,
+			)
+		);
+	}
 }


### PR DESCRIPTION
add testing to verify the fix for lowercase titles not showing.
ref: https://wordpress.org/support/topic/lowercase-post-titles-2/#post-8550569