### PR TITLE
version 1.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 - **Tags:** a to z, a-z, archive, listing, widget, index
 - **Requires at least:** 3.5
 - **Tested up to:** 4.7.2
-- **Stable tag:** 1.5.3
+- **Stable tag:** 1.5.4
 - **License:** GPLv2 or later
 - **License URI:** http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -225,6 +225,11 @@ In your theme's functions.php add the following code:
 ![The Widget is shown here.](https://ps.w.org/a-z-listing/assets/screenshot-2.png)
 
 ## Changelog
+
+### 1.5.4
+* Fix post links when using an alternative titles taxonomy (discovered by [bugnumber9](https://profiles.wordpress.org/bugnumber9))
+* Ensure that we don't access rogue objects. Warnings and errors in 1.5.3 are squashed now.
+* Verified that [tests](https://travis-ci.org/bowlhat/wp-a-z-listing) pass correctly before releasing this version.
 
 ### 1.5.3
 * Regression in 1.5.2 causing empty listing is fixed

--- a/changelog.md
+++ b/changelog.md
@@ -1,75 +1,85 @@
-= 1.5.1 =
+### 1.5.4
+* Fix post links when using an alternative titles taxonomy (discovered by [bugnumber9](https://profiles.wordpress.org/bugnumber9))
+
+### 1.5.3
+* Regression in 1.5.2 causing empty listing is fixed
+
+### 1.5.2
+* Regression fix for styling loading - seems the widget code was still causing issues
+* Add inline PHPdoc to all functions and custom filters
+
+### 1.5.1
 * Fix multiple post-types support for shortcode
 * Update documentation to explain how to show multiple post-types with the shortcode
 
-= 1.5.0 =
+### 1.5.0
 * Ensure styling is loaded correctly
 * Ensure styling works correctly when using the multi-column template
 
-= 1.4.1 =
+### 1.4.1
 * Fix warning introduced by 1.4.0 about implicit coercion between WP_Post and string
 
-= 1.4.0 =
+### 1.4.0
 * Add support for passing a WP_Post object instead of an ID to the widget function
 * Fix widget config not saving post-type parameter
 * Fix warning of incorrect usage of `has_shortcode()` function
 * Fix section-targeting to work as described
 
-= 1.3.1 =
+### 1.3.1
 * Fix broken admin pages caused by 1.3.0
 
-= 1.3.0 =
+### 1.3.0
 * Added targeted stylesheet loading to enqueue only on pages where the short-code is active
 * Further improved default stylesheet loading
 
-= 1.2.0 =
+### 1.2.0
 * Changed default to apply the in-built styles, unless overridden
 
-= 1.1.0 =
+### 1.1.0
 * Minor refactoring to remove unused variables
 * Fix some Code-Smell (phpcs)
 
-= 1.0.1 =
+### 1.0.1
 * BUGFIX: lower-case titles missing
 
-= 1.0.0 =
-* BREAKING CHANGE: Refactored several function names. If you have written your own template/loop you will need to adapt your code. See the readme.txt's Theming section for details.
+### 1.0.0
+* BREAKING CHANGE: Refactored several function names. If you have written your own template/loop you will need to adapt your code. See the readme's Theming section for details.
 * Added `post-type` attribute into the shortcode to display for post-types other than pages.
 * Minor code cleanup.
 
-= 0.8.0 =
-* Standardised on naming convention of *_a_z_* in function names, e.g. `get_the_a_z_listing()`, rather than the former *_az_* names, e.g. `get_the_az_listing()`.
+### 0.8.0
+* Standardised on naming convention of `*_a_z_*` in function names, e.g. `get_the_a_z_listing()`, rather than the former `*_az_*` names, e.g. `get_the_az_listing()`.
 * Converted version numbering to semver style.
 * Fixed the in-built styling.
 * Added filter to determine whether to apply in-built styles in addition to hidden setting: `set_option( a-z-listing-add-styling', true );`.
 * Added taxonomy terms list support.
 
-= 0.7.1 =
+### 0.7.1
 * Fix potential XSS vector.
 
-= 0.7 =
+### 0.7
 * rebuilt most of the logic in preparation for more functionality.
 * added template/theming capability (BIG change!)
 * Added option to choose to apply default styling of the widget.
 
-= 0.6 =
-* STYLING BREAKING change: the widget's CSS class is changed from bh_az_widget to a-z-listing-widget. Please update your CSS accordingly.
+### 0.6
+* STYLING BREAKING change: the widget's CSS class is changed from `bh_az_widget` to `a-z-listing-widget`. Please update your CSS accordingly.
 * Conformed to WordPress coding style guidelines.
 * Updated widget class to call php5-style constructor.
 * Applied internationalisation (i18n).
 * Added testsuite.
 
-= 0.5 =
+### 0.5
 * Added new shortcode to display the index page.
 
-= 0.4 =
+### 0.4
 * fixed file locations causing failure to load.
 
-= 0.3 =
-* fixed failure to activate as reported by ml413 and verified by geoffrey (both WordPress.org usernames); see: https://wordpress.org/support/topic/fatal-error-when-trying-to-install-1
+### 0.3
+* fixed failure to activate as reported by [ml413](https://profiles.wordpress.org/ml413) and verified by [creativejuiz](https://wordpress.org/support/users/creativejuiz/); [reference](https://wordpress.org/support/topic/fatal-error-when-trying-to-install-1).
 
-= 0.2 =
+### 0.2
 * renamed the plugin file and packaged for release
 
-= 0.1 =
+### 0.1
 * first release

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ### 1.5.4
 * Fix post links when using an alternative titles taxonomy (discovered by [bugnumber9](https://profiles.wordpress.org/bugnumber9))
+* Ensure that we don't access rogue objects. Warnings and errors in 1.5.3 are squashed now.
+* Verified that [tests](https://travis-ci.org/bowlhat/wp-a-z-listing) pass correctly before releasing this version.
 
 ### 1.5.3
 * Regression in 1.5.2 causing empty listing is fixed

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {},
     "scripts": {
-        "post-install-cmd": "[ -x \"vendor/bin/phpcs\" -a -d \"vendor/wp-coding-standards/wpcs\" ] && \"vendor/bin/phpcs\" --config-set installed_paths ../../../wp-coding-standards/wpcs",
-		"post-update-cmd" : "[ -x \"vendor/bin/phpcs\" -a -d \"vendor/wp-coding-standards/wpcs\" ] && \"vendor/bin/phpcs\" --config-set installed_paths ../../../wp-coding-standards/wpcs"
+        "post-install-cmd": "[ -x \"vendor/bin/phpcs\" -a -d \"vendor/wp-coding-standards/wpcs\" ] && \"vendor/bin/phpcs\" --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs",
+		"post-update-cmd" : "[ -x \"vendor/bin/phpcs\" -a -d \"vendor/wp-coding-standards/wpcs\" ] && \"vendor/bin/phpcs\" --config-set installed_paths ../../../vendor/wp-coding-standards/wpcs"
     }
 }

--- a/partials/a-z-shortcode.php
+++ b/partials/a-z-shortcode.php
@@ -21,7 +21,9 @@ function a_z_shortcode_handler( $attributes ) {
 
 	$post_types = explode( ',', $attributes['post-type'] );
 	$post_types = array_unique( $post_types );
-	$post_types = array_map( function( $item ) { return trim( $item ); }, $post_types );
+	$post_types = array_map( function( $item ) {
+		return trim( $item );
+	}, $post_types );
 
 	$query = array( 'post_type' => $post_types );
 	$a_z_query = new A_Z_Listing( $query );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: diddledan
 Tags: a to z, a-z, archive, listing, widget, index
 Requires at least: 3.5
 Tested up to: 4.7.2
-Stable tag: 1.5.3
+Stable tag: 1.5.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -222,6 +222,11 @@ In your theme's functions.php add the following code:
 2. The Widget is shown here.
 
 == Changelog ==
+
+= 1.5.4 =
+* Fix post links when using an alternative titles taxonomy (discovered by [bugnumber9](https://profiles.wordpress.org/bugnumber9))
+* Ensure that we don't access rogue objects. Warnings and errors in 1.5.3 are squashed now.
+* Verified that [tests](https://travis-ci.org/bowlhat/wp-a-z-listing) pass correctly before releasing this version.
 
 = 1.5.3 =
 * Regression in 1.5.2 causing empty listing is fixed

--- a/tests/test-widget.php
+++ b/tests/test-widget.php
@@ -6,8 +6,7 @@ class AZ_Widget_Tests extends WP_UnitTestCase {
 		$expected = sprintf( file_get_contents( 'tests/default-widget.txt' ), $p );
 		$expected = preg_replace( '/\s{2,}|\t|\n/', '', $expected );
 
-		$this->expectOutputString( $expected );
-
+		ob_start();
 		the_section_a_z_widget(
 			array(
 				'before_widget' => '<div>',
@@ -20,6 +19,10 @@ class AZ_Widget_Tests extends WP_UnitTestCase {
 				'post' => $p,
 			)
 		);
+		$actual = ob_get_clean();
+		$actual = preg_replace( '/\s{2,}|\t|\n/', '', $actual );
+
+		$this->assertEquals( $expected, $actual );
 	}
 	function test_populated_widget() {
 		$p = $this->factory->post->create( array( 'post_title' => 'Index Page', 'post_type' => 'page' ) );
@@ -28,8 +31,7 @@ class AZ_Widget_Tests extends WP_UnitTestCase {
 		$expected = sprintf( file_get_contents( 'tests/populated-widget.txt' ), $p );
 		$expected = preg_replace( '/\s{2,}|\t|\n/', '', $expected );
 
-		$this->expectOutputString( $expected );
-
+		ob_start();
 		the_section_a_z_widget(
 			array(
 				'before_widget' => '<div>',
@@ -42,6 +44,10 @@ class AZ_Widget_Tests extends WP_UnitTestCase {
 				'post' => $p,
 			)
 		);
+		$actual = ob_get_clean();
+		$actual = preg_replace( '/\s{2,}|\t|\n/', '', $actual );
+
+		$this->assertEquals( $expected, $actual );
 	}
 
 	function test_populated_widget_lowercase_titles() {
@@ -51,8 +57,7 @@ class AZ_Widget_Tests extends WP_UnitTestCase {
 		$expected = sprintf( file_get_contents( 'tests/populated-widget.txt' ), $p );
 		$expected = preg_replace( '/\s{2,}|\t|\n/', '', $expected );
 
-		$this->expectOutputString( $expected );
-
+		ob_start();
 		the_section_a_z_widget(
 			array(
 				'before_widget' => '<div>',
@@ -65,5 +70,9 @@ class AZ_Widget_Tests extends WP_UnitTestCase {
 				'post' => $p,
 			)
 		);
+		$actual = ob_get_clean();
+		$actual = preg_replace( '/\s{2,}|\t|\n/', '', $actual );
+
+		$this->assertEquals( $expected, $actual );
 	}
 }


### PR DESCRIPTION
* Fix post links when using an alternative titles taxonomy (discovered by [bugnumber9](https://profiles.wordpress.org/bugnumber9))
* Ensure that we don't access rogue objects. Warnings and errors in 1.5.3 are squashed now.
* update readme